### PR TITLE
Add AGENTS.md with URL ingestion and past-event cleanup rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS Instructions
+
+1. **When given a URL link:**
+   - Open the webpage and extract: **Date, Location, Meeting title and link, Registration Deadline, Abstract Deadline, Comments (other important info)**.
+   - Add a new row to the conference calendar markdown table using that information.
+   - Insert the new row in chronological order so the table remains sorted by **Date**.
+
+2. **When asked to clean the table/calendar:**
+   - Treat an event as outdated if its conference **Date is earlier than today**.
+   - Move outdated events from the main table to the table under **`#Past events`**.


### PR DESCRIPTION
### Motivation
- Provide concise, agent-facing rules so automated agents can add events from a provided URL and remove outdated events to keep the conference calendar accurate and sorted by `Date`.

### Description
- Add a root `AGENTS.md` that defines two workflows: extract `Date`, `Location`, `Meeting title and link`, `Registration Deadline`, `Abstract Deadline`, and `Comments` from a URL and insert a new row into the markdown calendar sorted by `Date`, and move events with a `Date` earlier than today from the main table into the `#Past events` section.

### Testing
- Created the file and verified repository state with `git commit` and `git status --short`, and inspected the file with `nl -ba AGENTS.md`, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c53bb144ac83289483c97de4d6ff32)